### PR TITLE
Backslashes for windows cmd script

### DIFF
--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -24,7 +24,7 @@ but then the application will be stopped when the user disconnects.
 
 **On windows** simply run:
 ```
-bin/semantic_forms_play.bat -J-Xmx50M &
+bin\semantic_forms_play.bat -J-Xmx50M &
 ```
 
 The default port is 9000, so you can direct your browser to [http://localhost:9000](http://localhost:9000) .


### PR DESCRIPTION
On the install command line, the windows version should use backslashes instead slashes.