### PR TITLE
Fix output format, and exception generated by empty result

### DIFF
--- a/scala/forms/src/main/scala/deductions/runtime/services/SPARQLHelpers.scala
+++ b/scala/forms/src/main/scala/deductions/runtime/services/SPARQLHelpers.scala
@@ -427,6 +427,7 @@ trait SPARQLHelpers[Rdf <: RDF, DATASET]
     val result = sparqlSelectQuery(queryString, ds)
     val output = result match {
       case Success(res) =>
+        if(!res.isEmpty){
         val header = res.head.map { node => literalNodeToString(node) }
         println(s"sparqlSelectXML: header $header")
 
@@ -464,7 +465,15 @@ trait SPARQLHelpers[Rdf <: RDF, DATASET]
               }
             </results>
           </sparql>
-        xml
+        xml     
+        }else{
+           val xml =
+              <sparql xmlns="http://www.w3.org/2005/sparql-results#">
+            		<head></head>
+								<results></results>
+							</sparql>
+              xml
+        }
       case Failure(f) => <sparql>
                            { f.getLocalizedMessage }
                          </sparql>

--- a/scala/forms_play/app/controllers/ApplicationTrait.scala
+++ b/scala/forms_play/app/controllers/ApplicationTrait.scala
@@ -354,12 +354,12 @@ trait ApplicationTrait extends Controller
 
 	private def renderResult(output: Accepting => Result, default: Accepting = AcceptsTTL)(implicit request: RequestHeader): Result = {
     render {
-      case AcceptsTTL    => output(AcceptsTTL)
-      case AcceptsJSONLD => output(AcceptsJSONLD)
-      case AcceptsRDFXML => output(AcceptsRDFXML)
-      case Accepts.Json  => output(Accepts.Json)
-      case Accepts.Xml   => output(Accepts.Xml)
-      case AcceptsSPARQLresults => output(AcceptsSPARQLresults)
+      case AcceptsTTL()    => output(AcceptsTTL)
+      case AcceptsJSONLD() => output(AcceptsJSONLD)
+      case AcceptsRDFXML() => output(AcceptsRDFXML)
+      case Accepts.Json()  => output(Accepts.Json)
+      case Accepts.Xml()   => output(Accepts.Xml)
+      case AcceptsSPARQLresults() => output(AcceptsSPARQLresults)
       case _             => output(default)
     }
   }
@@ -419,8 +419,7 @@ trait ApplicationTrait extends Controller
 
           // TODO better try a parse of the query
           def checkSPARQLqueryType(query: String) =
-            if (query.contains("select") ||
-              query.contains("SELECT"))
+            if (query.toLowerCase().contains("select") )
               "select"
             else
               "construct"
@@ -477,8 +476,7 @@ trait ApplicationTrait extends Controller
 
         // TODO better try a parse of the query
         def checkSPARQLqueryType(query: String) =
-          if (query.contains("select") ||
-            query.contains("SELECT"))
+          if (query.toLowerCase().contains("select") )
             "select"
           else
             "construct"
@@ -505,7 +503,7 @@ trait ApplicationTrait extends Controller
     val mime = computeMIME(acceptedTypes, defaultMIME)
     println(s"sparqlConstruct: computed mime ${mime}")
 
-    val resultFormat = mimeAbbrevs(defaultMIMEaPriori) // preferredMedia.getOrElse(defaultMIME))
+    val resultFormat = mimeAbbrevs(defaultMIME) // preferredMedia.getOrElse(defaultMIME))
     println(s"sparqlConstruct: output(accepts=$acceptedTypes) => result format: $resultFormat")
     if (preferredMedia.isDefined &&
       !mimeSet.contains(preferredMedia.get))


### PR DESCRIPTION
+ Output format fixed according to the http Accept Header
+ Little update on parsing query in order to find "SELECT" ("Select" was not found for exemple)
+ An empty result in the function sparqlSelectXML was generating an exception like in sparqlSelectJSON.
Now empty result is returned in the following form :
```
<sparql xmlns="http://www.w3.org/2005/sparql-results#">
<head></head>
<results></results>
</sparql>
```